### PR TITLE
vaccine outreach column populated

### DIFF
--- a/opensrp-child/src/main/java/org/smartregister/child/util/Utils.java
+++ b/opensrp-child/src/main/java/org/smartregister/child/util/Utils.java
@@ -211,7 +211,7 @@ public class Utils extends org.smartregister.util.Utils {
             String providerId = allSharedPreferences.fetchRegisteredANM();
             vaccine.setTeam(allSharedPreferences.fetchDefaultTeam(providerId));
             vaccine.setTeamId(allSharedPreferences.fetchDefaultTeamId(providerId));
-
+            vaccine.setOutreach(vaccine.getLocationId().equals(allSharedPreferences.fetchDefaultLocalityId(providerId))? 0 : 1);
             vaccine.setName(vaccine.getName().trim());
             // Add the vaccine
             vaccineRepository.add(vaccine);


### PR DESCRIPTION
added outreach column population for the condition if the vaccine locationID is not the main facility locationID then it is set to 1 else 0 in order to detect vaccines given in outreach or  in the facility 
issue ref # https://github.com/opensrp/opensrp-client-path-zeir/issues/193